### PR TITLE
Ingest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ doc/
 *.swp
 *-
 .project
+nbproject
 .DS_Store
 .idea
 ./sample.xml

--- a/README.md
+++ b/README.md
@@ -2,10 +2,7 @@
 
 # bostonlocaltv
 
-
-Site: http://bostonlocaltv.org/
-
-Documentation: https://github.com/WGBH/bostonlocaltv/wiki
+[http://bostonlocaltv.org/]
 
 - Funded by the Institute of Museum and Library Services and the Council on Library and Information Resources. 
 - Collaborators:
@@ -13,3 +10,13 @@ Documentation: https://github.com/WGBH/bostonlocaltv/wiki
   - Cambridge Community Television (1988 to 1999)
   - Northeast Historic Film’s WCVB film collection (1970-1979)
   - WGBH-produced The Reporters (1970-1973), Evening Compass (1973-1975) and the Ten O’Clock News
+
+## Ingest
+
+PBCore collection documents should be kept in [S3](https://console.aws.amazon.com/s3/home?region=us-east-1#&bucket=bostonlocaltv.org&prefix=pbcore/)
+with conventional names. All S3 docs can be downloaded and reingested with `script/ingest.sh`.
+
+## Old Documentation
+
+Old docs are available here: https://github.com/WGBH/bostonlocaltv/wiki.
+I plan to replace them over time with current information here in the readme.

--- a/script/ingest.sh
+++ b/script/ingest.sh
@@ -1,4 +1,7 @@
 for ORG in cctv wcvb wgbh whdh; do
   echo "Ingest $ORG"
-  rake data:$ORG RAILS_ENV=development file=../bostonlocaltv-s3/pbcore/$ORG.pbcore.xml
+  FILE=$ORG.pbcore.xml
+  rm /tmp/$FILE
+  curl https://s3.amazonaws.com/bostonlocaltv.org/pbcore/$FILE > /tmp/$FILE
+  rake data:$ORG file=/tmp/$FILE
 done

--- a/script/ingest.sh
+++ b/script/ingest.sh
@@ -1,0 +1,4 @@
+for ORG in cctv wcvb wgbh whdh; do
+  echo "Ingest $ORG"
+  rake data:$ORG RAILS_ENV=development file=../bostonlocaltv-s3/pbcore/$ORG.pbcore.xml
+done


### PR DESCRIPTION
@sroosa : Going forward, the system will expect PBCore for ingest to be found on [S3](https://console.aws.amazon.com/s3/home?region=us-east-1#&bucket=bostonlocaltv.org&prefix=pbcore/). We had talked about just combining all the sources, but [it turns out](https://github.com/WGBH/bostonlocaltv/issues/187) each source is processed differently, so that's not feasible right now.

This supersedes the instructions in the [wiki](https://github.com/WGBH/bostonlocaltv/wiki/Ingest).

@foo4thought : code review and merge?

(Noticed that tests just failed: I'll rebase, and hope that works.)