### PR TITLE
Loop over single valued fields

### DIFF
--- a/app/controllers/oai_controller.rb
+++ b/app/controllers/oai_controller.rb
@@ -1,5 +1,5 @@
 class OaiController < ApplicationController
-  Record = Struct.new(:id, :date, :title, :descriptions, :subjects, :video, :locations, :date_created, :names)
+  Record = Struct.new(:id, :date, :title, :descriptions, :subjects, :video, :locations, :names, :date_created, :date_broadcast, :audio_duration, :collection)
   ROWS = 100
 
   def index
@@ -26,7 +26,7 @@ class OaiController < ApplicationController
              'rows' => ROWS,
              'start' => start
            })['response']['docs'].map do |d|
-        Record.new(d['id'], d['timestamp'], d['title_s'], d['description_s'], d['subject_s'], d['video_b'], d['location_s'], d['date_created_s'], d['name_s'])
+        Record.new(d['id'], d['timestamp'], d['title_s'], d['description_s'], d['subject_s'], d['video_b'], d['location_s'], d['name_s'], d['date_created_s'], d['date_broadcast_s'], d['audio_duration_s'], d['collection_s'])
       end
 
     # Not ideal: they'll need to go past the end.

--- a/app/views/oai/index.xml.erb
+++ b/app/views/oai/index.xml.erb
@@ -40,7 +40,7 @@
                         }
                         x.physicalDescription {
                           x.extent(record.duration)
-                        } if record.duration
+                        } if record.audio_duration
                         record.descriptions.each do |description|
                           x.abstract(description)
                         end if record.descriptions

--- a/app/views/oai/index.xml.erb
+++ b/app/views/oai/index.xml.erb
@@ -23,6 +23,7 @@
                             x.title(title)
                           }
                         end if record.title
+                        # TODO: Need to update Solr schema to store contributor name and role separately in order to map here
                         #x.name('PERSON NAME') {
                           #x.role {
                             #x.roleTerm('PERSON ROLE')
@@ -33,12 +34,13 @@
                         # hardcoding News value here because all records in this app are News stories
                         x.genre('News')
                         x.originInfo {
-                          #x.publisher('PUBLISHER')
-                          x.dateCreated(record.date_created)
-                        } if record.date_created
-                        #x.physicalDescription {
-                          #x.extent('DURATION')
-                        #}
+                          x.publisher(record.collection)
+                          x.dateCreated(record.date_created) if record.date_created
+                          x.dateIssued(record.date_broadcast) if record.date_broadcast
+                        }
+                        x.physicalDescription {
+                          x.extent(record.duration)
+                        } if record.duration
                         record.descriptions.each do |description|
                           x.abstract(description)
                         end if record.descriptions

--- a/app/views/oai/index.xml.erb
+++ b/app/views/oai/index.xml.erb
@@ -39,7 +39,7 @@
                           x.dateIssued(record.date_broadcast) if record.date_broadcast
                         }
                         x.physicalDescription {
-                          x.extent(record.duration)
+                          x.extent(record.audio_duration)
                         } if record.audio_duration
                         record.descriptions.each do |description|
                           x.abstract(description)

--- a/app/views/oai/index.xml.erb
+++ b/app/views/oai/index.xml.erb
@@ -42,7 +42,7 @@
                           end if record.date_created
                           record.date_broadcast.each do |date_broadcast|
                             x.dateIssued(date_broadcast)
-                          end if record.cdate_broadcast
+                          end if record.date_broadcast
                         }
                         record.audio_duration.each do |audio_duration|
                         x.physicalDescription {

--- a/app/views/oai/index.xml.erb
+++ b/app/views/oai/index.xml.erb
@@ -34,13 +34,21 @@
                         # hardcoding News value here because all records in this app are News stories
                         x.genre('News')
                         x.originInfo {
-                          x.publisher(record.collection)
-                          x.dateCreated(record.date_created) if record.date_created
-                          x.dateIssued(record.date_broadcast) if record.date_broadcast
+                          record.collection.each do |collection|
+                            x.publisher(collection)
+                          end if record.collection
+                          record.date_created.each do |date_created|
+                            x.dateCreated(date_created)
+                          end if record.date_created
+                          record.date_broadcast.each do |date_broadcast|
+                            x.dateIssued(date_broadcast)
+                          end if record.cdate_broadcast
                         }
+                        record.audio_duration.each do |audio_duration|
                         x.physicalDescription {
-                          x.extent(record.audio_duration)
-                        } if record.audio_duration
+                          x.extent(audio_duration)
+                        }
+                        end if record.audio_duration
                         record.descriptions.each do |description|
                           x.abstract(description)
                         end if record.descriptions


### PR DESCRIPTION
To avoid [" "]s around values, we needed to loop over the single valued fields, even though there's only one value. 